### PR TITLE
ADD(changelog): Se agrega estándar de CHANGELOG y skill scisa-changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
 # SCISA org-guidelines
 
-## unreleased
+## Unreleased
 
-### Changes
-- Se agrega informacion de estructura de PLD
-- Adds a refactoring guideline
+### Added
+- Se agregan guías de introducción para el repositorio
+- Se crea guía organizacional para manuales de usuario
+- Se agregan políticas de evaluación y aprobación de librerías de terceros
+
+### Changed
+- Se agrega información de estructura de PLD
+- Se agrega guía de refactoring
+
+### Removed
+- Se elimina la sección 8 (scripts) por falta de acuerdo organizacional

--- a/docs/programming/0.6.git/06.3.commits_rules.md
+++ b/docs/programming/0.6.git/06.3.commits_rules.md
@@ -205,15 +205,19 @@ the logic to reduce inconsistency and improve testability.
 ### Tipos estándar permitidos
 La tabla se mantiene como estándar del equipo
 
-| Tipo     | Uso                                       |
-| -------- | ----------------------------------------- |
-| feat/add | Nueva funcionalidad                       |
-| fix      | Corrección de bug                         |
-| refactor | Cambio interno sin alterar comportamiento |
-| test     | Tests nuevos o ajustados                  |
-| docs     | Documentación                             |
-| chore    | Tareas técnicas sin impacto funcional     |
-| bump     | Actualización de dependencias y/o versión |
+| Tipo     | Uso                                                        |
+| -------- | ---------------------------------------------------------- |
+| feat/add | Nueva funcionalidad                                        |
+| fix      | Corrección de bug                                          |
+| perf     | Mejora de rendimiento con impacto visible al usuario       |
+| security | Corrección de vulnerabilidad o cambio de seguridad         |
+| refactor | Cambio interno sin alterar comportamiento ni rendimiento   |
+| test     | Tests nuevos o ajustados                                   |
+| docs     | Documentación                                              |
+| chore    | Tareas técnicas sin impacto funcional                      |
+| bump     | Actualización de dependencias y/o versión                  |
+
+> `perf` y `security` aparecen en el CHANGELOG. `refactor` no aparece — si el cambio tiene impacto visible al usuario, usa `perf` en su lugar.
 
 ### Formato orientado a corrección crítica
 

--- a/docs/programming/0.7.repositories/07.2.releases.md
+++ b/docs/programming/0.7.repositories/07.2.releases.md
@@ -1,2 +1,133 @@
-# Reglas para releases
+# Releases y CHANGELOG
 
+Un release comunica qué se entregó. El CHANGELOG es el artefacto que lo documenta.
+
+Podemos haber hecho un desarrollo excelente, pero si no lo comunicamos, nadie sabrá qué se arregló, qué se agregó o qué se eliminó. La comunicación es tan importante como el desarrollo.
+
+## ¿Qué es un CHANGELOG?
+
+Un archivo `CHANGELOG.md` en la raíz del proyecto que registra todos los cambios relevantes por versión. Es la fuente de verdad para lo que se ha entregado en producción.
+
+Lo leen: desarrolladores, enlaces de negocio, clientes y usuarios finales. Escríbelo para todos.
+
+## Buenas prácticas
+
+- Actualízalo conforme avanzas, no al final del sprint
+- Agrupa los cambios por tipo
+- Incluye la fecha del release
+- Usa versionado semántico (ver `07.3.semantic_versioning.md`)
+- La versión más reciente va hasta arriba
+- Una entrada por versión
+- Incluye el número de ticket si aplica: `[NÚMERO]`
+
+## Formato
+
+```markdown
+# Nombre de la aplicación
+
+## Unreleased
+
+### Fixed
+- [TICKET] Descripción funcional
+
+### Added
+- [TICKET] Descripción funcional
+
+### Changed
+- [TICKET] Descripción del cambio o mejora de rendimiento
+
+### Deprecated
+- [TICKET] Lo que será eliminado en futuras versiones
+
+### Removed
+- [TICKET] Lo que fue eliminado
+
+### Security
+- [TICKET] Cambios relacionados con vulnerabilidades o seguridad
+```
+
+Solo incluir las secciones que aplican. No agregar secciones vacías.
+
+## Tipos de cambio
+
+| Tipo | Qué registrar |
+|---|---|
+| `Fixed` | Correcciones de bugs — algo no funcionaba y ahora sí |
+| `Added` | Nueva funcionalidad |
+| `Changed` | Mejoras a funcionalidad existente, incluyendo mejoras de rendimiento |
+| `Deprecated` | Algo que será eliminado en versiones futuras |
+| `Removed` | Funcionalidad eliminada |
+| `Security` | Correcciones de vulnerabilidades o cambios de seguridad |
+
+## Referencia de tickets
+
+El número de ticket va entre corchetes al inicio de cada entrada: `[8527]`.
+
+El equipo usa Azure DevOps y ClickUp. El formato `[NÚMERO]` sin prefijo de sistema es el estándar para mantener el CHANGELOG independiente de la herramienta.
+
+## Flujo de trabajo
+
+### Durante el desarrollo
+
+Todo cambio nuevo va en `## Unreleased`. Si no existe esa sección, agrégala.
+
+```markdown
+## Unreleased
+
+### Added
+- [8440] Opción para importar inversionistas
+```
+
+### Al hacer un release
+
+Toma el bloque `Unreleased`, asígnale versión y fecha, y colócalo arriba:
+
+```markdown
+## v1.3.1 - 2025-04-29
+
+### Fixed
+- [8527] Permite importar personas físicas sin país de nacimiento
+
+### Added
+- [8440] Opción para importar inversionistas
+```
+
+Después del release, crea un nuevo `## Unreleased` vacío para el próximo ciclo.
+
+### Regla crítica
+
+Las versiones cerradas (con número y fecha) **no se modifican**. Solo se edita lo que aún no ha sido liberado.
+
+## Automatización con Claude Code
+
+El skill `scisa-changelog` está disponible en `.claude/skills/scisa-changelog/` de este repo.
+
+Genera entradas desde el historial de commits:
+
+```
+Genera el changelog de los commits desde el último release
+```
+
+```
+Cierra el Unreleased como v1.4.0 con la fecha de hoy --write
+```
+
+Ver `SKILL.md` del skill para referencia completa.
+
+## Relación con versionado semántico
+
+Todo release debe incluir:
+
+- Tag en Git (`v2.1.0`)
+- Entradas en `CHANGELOG.md`
+- Fecha y responsable
+
+El tipo de cambio en el CHANGELOG guía el incremento de versión:
+
+| CHANGELOG | Impacto semántico |
+|---|---|
+| Solo `Fixed` | PATCH |
+| Incluye `Added` | MINOR |
+| Incluye `Removed` o breaking change | MAJOR |
+
+Ver `07.3.semantic_versioning.md` para reglas completas.

--- a/skills/scisa-changelog/SKILL.md
+++ b/skills/scisa-changelog/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: scisa-changelog
+description: Genera entradas de CHANGELOG para proyectos SCISA siguiendo el formato organizacional. Analiza commits de git, los categoriza según los tipos estándar y produce entradas en español listas para agregar a CHANGELOG.md. Por defecto propone el output; con --write lo escribe directo al archivo.
+---
+
+# SCISA Changelog Generator
+
+Skill organizacional para generar y mantener CHANGELOG.md siguiendo el estándar SCISA.
+
+## Cuándo usar este skill
+
+- Preparar entradas de changelog antes de un release
+- Cerrar el bloque `## Unreleased` con número de versión y fecha
+- Agregar entradas durante el desarrollo (conforme avanza, no al final)
+- Revisar qué cambios van en el próximo release
+
+## Formato del CHANGELOG
+
+El archivo se llama `CHANGELOG.md` y vive en la raíz del proyecto.
+
+```markdown
+# Nombre de la aplicación
+
+## Unreleased
+
+### Fixed
+- [TICKET] Descripción funcional del fix
+
+### Added
+- [TICKET] Descripción funcional del feature
+
+### Changed
+- [TICKET] Descripción del cambio o mejora de rendimiento
+
+### Deprecated
+- [TICKET] Lo que será eliminado en futuras versiones
+
+### Removed
+- [TICKET] Lo que fue eliminado
+
+### Security
+- [TICKET] Cambios relacionados con vulnerabilidades o seguridad
+```
+
+Al hacer release, el bloque `Unreleased` se convierte en versión con fecha:
+
+```markdown
+## v1.3.1 - 2025-04-29
+
+### Fixed
+- [8527] Permite importar personas físicas sin país de nacimiento
+```
+
+## Reglas de formato
+
+- Idioma: **español**
+- Referencia de ticket: `[NÚMERO]` al inicio de cada entrada (Azure DevOps o ClickUp)
+- Si el commit no tiene ticket, omitir el prefijo
+- Una línea por cambio, concisa y funcional
+- El lector puede ser desarrollador, negocio o usuario final — escribir para todos
+- Versión más reciente arriba siempre
+- Solo una sección `## Unreleased` activa en cualquier momento
+- Las versiones cerradas (con número y fecha) **no se modifican**
+
+## Mapeo commits → secciones
+
+| Tipo de commit | Sección CHANGELOG | Incluir |
+|---|---|---|
+| `feat` / `add` | `Added` | Sí |
+| `fix` | `Fixed` | Sí |
+| `perf` | `Changed` | Sí |
+| `security` | `Security` | Sí |
+| `refactor` | — | No (usar `perf` si hay impacto visible) |
+| `docs` | — | No |
+| `test` | — | No |
+| `chore` | — | No |
+| `bump` | — | No |
+| Breaking change | `Removed` / `Deprecated` | Sí |
+
+## Cómo usar
+
+### Proponer entradas (default)
+
+```
+Genera el changelog de los commits desde el último release
+```
+
+```
+Genera las entradas de changelog de la última semana
+```
+
+```
+¿Qué va en el CHANGELOG para la versión 2.1.0?
+```
+
+### Escribir directo al archivo
+
+```
+Genera el changelog de los últimos commits --write
+```
+
+```
+Cierra el bloque Unreleased como v1.4.0 hoy --write
+```
+
+### Cerrar una versión
+
+```
+Cierra el Unreleased como versión 1.4.0 con la fecha de hoy
+```
+
+El skill toma todo lo que está en `## Unreleased`, lo mueve a `## v1.4.0 - FECHA` y crea un nuevo `## Unreleased` vacío.
+
+## Proceso del skill
+
+1. Leer el rango de commits indicado (`git log` desde el tag anterior o fecha especificada)
+2. Filtrar commits según la tabla de mapeo (excluir `refactor`, `docs`, `test`, `chore`, `bump`)
+3. Extraer número de ticket del mensaje (`[NÚMERO]` al inicio de la descripción)
+4. Traducir el mensaje técnico a lenguaje funcional en español
+5. Agrupar por sección (`Fixed`, `Added`, `Changed`, `Deprecated`, `Removed`, `Security`)
+6. Si `--write`: append al bloque `## Unreleased` existente en `CHANGELOG.md`
+7. Si no `--write`: mostrar el output propuesto para revisión del dev
+
+## Ejemplo
+
+**Commits en el repo:**
+```
+feat: [8440] agregar opción para importar inversionistas
+fix: [8527] permitir importar personas físicas sin país de nacimiento
+perf: [7227] optimizar consulta de importación de personas
+chore: actualizar dependencias de NuGet
+test: agregar unit tests para importación
+security: [9091] corregir vulnerabilidad en validación de LOGIN
+```
+
+**Output propuesto:**
+```markdown
+### Fixed
+- [8527] Permite importar personas físicas sin país de nacimiento
+
+### Added
+- [8440] Opción para importar inversionistas
+
+### Changed
+- [7227] Mejora en el tiempo de importación de personas (50% más rápido)
+
+### Security
+- [9091] Se corrigió una vulnerabilidad en la validación del LOGIN
+```
+
+## Referencia
+
+- Estándar organizacional: `docs/programming/0.7.repositories/07.2.releases.md`
+- Tipos de commit: `docs/programming/0.6.git/06.3.commits_rules.md`
+- Versionamiento semántico: `docs/programming/0.7.repositories/07.3.semantic_versioning.md`
+- Inspirado en: [Keep a Changelog](https://keepachangelog.com/es-ES/1.0.0/)


### PR DESCRIPTION
- Se define política de CHANGELOG en 07.2.releases.md: formato, tipos de cambio, flujo Unreleased → versión, referencia de tickets [NÚMERO]
- Se agrega skill scisa-changelog en skills/scisa-changelog/ con mapeo commit→sección, modo propuesta y --write
- Se añaden tipos perf y security a 06.3.commits_rules.md
- Se corrige CHANGELOG.md del repo al formato organizacional